### PR TITLE
When initializing a Frodo::Service, use a later discarded Frodo::Client to fetch the metadata

### DIFF
--- a/lib/frodo/concerns/api.rb
+++ b/lib/frodo/concerns/api.rb
@@ -42,7 +42,7 @@ module Frodo
 
       def metadata_on_init
         # Creating Metadata using a different client than the one that is stored
-        Frodo::Client.new(@options).get("$metadata").body
+        Frodo::Client.new(@options).api_get("$metadata").body
       end
 
       # Public: Execute a query and returns the result.

--- a/lib/frodo/concerns/api.rb
+++ b/lib/frodo/concerns/api.rb
@@ -40,6 +40,11 @@ module Frodo
         api_get("$metadata").body
       end
 
+      def metadata_on_init
+        # Creating Metadata using a different client than the one that is stored
+        Frodo::Client.new(@options).get("$metadata").body
+      end
+
       # Public: Execute a query and returns the result.
       #
       # Query can be the url_chunk per the OData V4 spec or

--- a/lib/frodo/concerns/base.rb
+++ b/lib/frodo/concerns/base.rb
@@ -73,7 +73,7 @@ module Frodo
       end
 
       def service
-        @service ||= Frodo::Service.new(instance_url, strict: false, metadata_document: metadata)
+        @service ||= Frodo::Service.new(instance_url, strict: false, metadata_document: metadata_on_init)
       end
 
       def inspect


### PR DESCRIPTION
Frodo out of the box will fetch the OData schema for a given instance URL. By default it uses the same client that it returns to you when you call Frodo.new

Interestingly this makes it impossible to change the middleware and initialize the Frodo client without providing the Frodo::Client a Frodo::Service object that is loaded with the Schema (which requires you to have an initialized Frodo::Client). There is circular dependency. Ultimately with pretty hard dependency on having the Schema at start up and considering we will always have to deal with not having the schema in the cache at somepoint we need a way to fetch the schema on a cold start that does not lock the Frodo::Client's middleware.

This is my attempt at solving that, which I do by creating a new metadata method, that makes a Frodo::Client using the same options, calls the same endpoint, and returns the same schema, but the client that is used is different from the one we create when initializing Frodo.

I think this is ok, the only invocation of this method is when there is no pre-loaded service object provided in the options (and this only happens when we don't have a schema cached).

The downside is, this cold call will have none of the middle ware. I think this needs to be fixed in the long run. At the moment there is one only one additional middleware we try to insert and as a result is not in the chain when we do this call. It's logging so arguably fairly important, as a workaround one can use the Frodo::Client.metadata method to get a logged output, but this will not be the case for for a cold initialization of the client.

I think we need to do a bigger refactor to Frodo though to support a workflow that would support adding the middleware before the Frodo::Client is forced to call for metadata.

I am curious what other people think about this approach? Assuming they are good with it, I will create a TODO / JIRA and update this PR. Also I'll fix the broken test which is failing due to the change I made.