### PR TITLE
add option to pass navigation properties into the client

### DIFF
--- a/lib/frodo/config.rb
+++ b/lib/frodo/config.rb
@@ -136,6 +136,9 @@ module Frodo
     # Set a log level for logging when Frodo.log is set to true, defaulting to :debug
     option :log_level, default: :debug
 
+    # Optionally set the navigation properties to improve performance of the client
+    option :navigation_properties
+
     def options
       self.class.options
     end

--- a/lib/frodo/schema.rb
+++ b/lib/frodo/schema.rb
@@ -12,9 +12,10 @@ module Frodo
     #
     # @param schema_definition [Nokogiri::XML] The schema's XML definition
     # @param service [Frodo::Service] The schema's parent service
-    def initialize(schema_definition, service)
+    def initialize(schema_definition, service, navigation_properties=nil)
       @metadata = schema_definition
       @service = service
+      @navigation_properties = navigation_properties
     end
 
     # Returns the schema's `Namespace` attribute (mandatory).

--- a/lib/frodo/service.rb
+++ b/lib/frodo/service.rb
@@ -48,7 +48,7 @@ module Frodo
       @schemas ||= metadata.xpath('//Schema').map do |schema_xml|
         [
           schema_xml.attributes['Namespace'].value,
-          Schema.new(schema_xml, self)
+          Schema.new(schema_xml, self, options[:navigation_properties])
         ]
       end.to_h
     end

--- a/lib/frodo/version.rb
+++ b/lib/frodo/version.rb
@@ -1,3 +1,3 @@
 module Frodo
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/frodo/schema_spec.rb
+++ b/spec/frodo/schema_spec.rb
@@ -74,6 +74,12 @@ describe Frodo::Schema do
       it { expect(subject.navigation_properties['email']['activitypointer_activity_parties']).to be_a(Frodo::NavigationProperty) }
     end
 
+    context "with navigation properties provided during initialization" do
+      let(:navigation_properties) { { key: "value" } }
+      let(:subject) { Frodo::Schema.new(schema_xml, service, navigation_properties) }
+
+      it { expect(subject.navigation_properties).to eq(navigation_properties) }
+    end
   end
 
   describe '#referential_constraints_for_entity' do


### PR DESCRIPTION
This adds an optional setting to provide the navigation_properties, similar to how the schema can be provided. If the navigation_properties are provided the client will not generate the properties which can improve performance of operations that depend on the navigation_properties in order to have their response built (ex. any Query).