### PR TITLE
Modify default value for integer type when nil is allowed

### DIFF
--- a/lib/frodo/properties/integer.rb
+++ b/lib/frodo/properties/integer.rb
@@ -18,7 +18,11 @@ module Frodo
       # @params new_value [to_i]
       def value=(new_value)
         validate(new_value.to_i)
-        @value = new_value.to_i.to_s
+        @value = if new_value.nil? && allows_nil?
+                   nil
+                 else
+                   new_value.to_i.to_s
+                 end
       end
 
       # The Frodo type name

--- a/spec/frodo/properties/integer_spec.rb
+++ b/spec/frodo/properties/integer_spec.rb
@@ -7,11 +7,14 @@ describe Frodo::Properties::Integer do
   let(:subject64) { Frodo::Properties::Int64.new('Int64', '32') }
   let(:subjectbyte) { Frodo::Properties::Byte.new('Byte', '32') }
   let(:subjectsbyte) { Frodo::Properties::SByte.new('SByte', '32') }
+  let(:subjectnullable) { Frodo::Properties::Integer.new('Integer', '32', 'allows_nil'=>true) }
 
   it { expect(subject.type).to eq('Edm.Int64') }
   it { expect(subject.value).to eq(32) }
   it { expect {subject.value = (2**63)}.to raise_error(ArgumentError) }
   it { expect {subject.value = (-(2**63) - 1)}.to raise_error(ArgumentError) }
+
+  
 
   it { expect(subject16.type).to eq('Edm.Int16') }
   it { expect(subject16.value).to eq(32) }
@@ -46,6 +49,7 @@ describe Frodo::Properties::Integer do
       subject64.value = 128
       subjectbyte.value = 12
       subjectsbyte.value = 12
+      subjectnullable.value = nil
     end
 
     it { expect(subject.value).to eq(128) }
@@ -54,5 +58,6 @@ describe Frodo::Properties::Integer do
     it { expect(subject64.value).to eq(128) }
     it { expect(subjectbyte.value).to eq(12) }
     it { expect(subjectsbyte.value).to eq(12) }
+    it { expect(subjectnullable.value).to eq(nil) }
   end
 end


### PR DESCRIPTION
So some of the values of type Integer will come back as 'nil' form Dynamics and frodo would change it to '0'. This commit has to fix this behavior and return 'nil' if 'allows_nil' set to TRUE