### PR TITLE
[DWF-3796]Added with_metadata option to service

### DIFF
--- a/lib/frodo/concerns/api.rb
+++ b/lib/frodo/concerns/api.rb
@@ -41,7 +41,7 @@ module Frodo
 
       def metadata_on_init
         # Creating Metadata using a different client than the one that is stored
-        Frodo::Client.new(@options).api_get("$metadata").body
+        Frodo::Client.new(@options).api_get("$metadata").body unless @options[:with_metadata]
       end
 
       # Public: Execute a query and returns the result.

--- a/lib/frodo/concerns/base.rb
+++ b/lib/frodo/concerns/base.rb
@@ -56,6 +56,8 @@ module Frodo
       #
       #        :request_headers         - A hash containing custom headers that will be
       #                                   appended to each request
+      #
+      #        :with_metadata           - Flag to specify if we need to use metadata
 
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)
@@ -78,7 +80,7 @@ module Frodo
       end
 
       def service
-        @service ||= Frodo::Service.new(instance_url, strict: false, metadata_document: metadata_on_init)
+        @service ||= Frodo::Service.new(instance_url, strict: false, metadata_document: metadata_on_init, with_metadata: options[:with_metadata] )
       end
 
       def inspect

--- a/lib/frodo/service.rb
+++ b/lib/frodo/service.rb
@@ -21,7 +21,7 @@ module Frodo
       @service_url = service_url
 
       Frodo::ServiceRegistry.add(self)
-      register_custom_types
+      register_custom_types unless options[:with_metadata]
     end
 
     # Returns user supplied name for service, or its URL

--- a/spec/frodo/concerns/base_spec.rb
+++ b/spec/frodo/concerns/base_spec.rb
@@ -8,6 +8,7 @@ describe Frodo::Concerns::Base do
     context = self
     Class.new {
       include Frodo::Concerns::Connection
+      include Frodo::Concerns::API
       include context.described_class
     }
   end
@@ -42,6 +43,41 @@ describe Frodo::Concerns::Base do
   describe '.options' do
     subject { lambda { client.options } }
     it { should_not raise_error }
+  end
+
+  describe '.service' do
+    subject { client.service }
+    before do
+      allow(client).to receive(:instance_url).and_return("some_url")
+      allow(client).to receive(:metadata_on_init).and_return("")
+    end
+
+    context 'when with_metadata is true' do
+      before { allow(client).to receive(:options).and_return({ with_metadata: true }) }
+
+      it 'service options contains :with_metadata' do
+        expect(subject.options.has_key?(:with_metadata)).to be_truthy
+        expect(subject.options[:with_metadata]).to be_truthy
+      end
+    end
+
+    context 'when with_metadata is false' do
+      before { allow(client).to receive(:options).and_return({ with_metadata: false }) }
+
+      it 'service options contains :with_metadata' do
+        expect(subject.options.has_key?(:with_metadata)).to be_truthy
+        expect(subject.options[:with_metadata]).to be_falsey
+      end
+    end
+
+    context 'when with_metadata not presented in options' do
+      before { allow(client).to receive(:options).and_return({}) }
+
+      it 'service options contains :with_metadata' do
+        expect(subject.options.has_key?(:with_metadata)).to be_truthy
+        expect(subject.options[:with_metadata]).to be_falsey
+      end
+    end
   end
 
   describe '.instance_url' do


### PR DESCRIPTION
We need to load metadata only when 'with_metadata' attribute presented.
https://outreach-io.atlassian.net/browse/DWF-3796