### PR TITLE
Fix client credentials authentication

### DIFF
--- a/lib/frodo/middleware/authentication/client_credentials.rb
+++ b/lib/frodo/middleware/authentication/client_credentials.rb
@@ -2,9 +2,12 @@ module Frodo
   # Authentication middleware used if client_id, client_secret, and client_credentials: true are set
   class Middleware::Authentication::ClientCredentials < Frodo::Middleware::Authentication
     def params
-      { grant_type: 'client_credentials',
+      {
+        grant_type: 'client_credentials',
         client_id: @options[:client_id],
-        client_secret: @options[:client_secret] }
+        client_secret: @options[:client_secret],
+        resource: @options[:instance_url]
+      }
     end
   end
 end


### PR DESCRIPTION
In order to make the client credentials authentication working there is only need to add additional parameter in the token request named resource with the url of the dataverse instance 